### PR TITLE
feat: add option to sort by a column

### DIFF
--- a/src/@types/parseable/api/query.ts
+++ b/src/@types/parseable/api/query.ts
@@ -4,9 +4,18 @@ export type LogsQuery = {
 	endTime: Date;
 };
 
+export enum SortOrder {
+	ASCENDING = 1,
+	DESCENDING = -1
+}
+
 export type LogsSearch = {
 	search: string;
 	filters: Record<string, string[]>;
+	sort: {
+		field: string,
+		order: SortOrder
+	}
 };
 
 export type LogsData = {

--- a/src/hooks/useQueryLogs.ts
+++ b/src/hooks/useQueryLogs.ts
@@ -63,8 +63,8 @@ export const useQueryLogs = () => {
 			temp.sort(({[field]: aData}, {[field]: bData}) => {
 				let res = 0
 				if (aData === bData) res = 0;
-				else if (aData == null) res = -1;
-				else if (bData == null) res = 1;
+				else if (aData === null) res = -1;
+				else if (bData === null) res = 1;
 				else res = aData > bData ? 1 : -1;
 
 				return res*order;

--- a/src/layouts/MainLayout/Context.tsx
+++ b/src/layouts/MainLayout/Context.tsx
@@ -1,4 +1,4 @@
-import type { LogsQuery, LogsSearch } from '@/@types/parseable/api/query';
+import { SortOrder, type LogsQuery, type LogsSearch } from '@/@types/parseable/api/query';
 import useSubscribeState, { SubData } from '@/hooks/useSubscribeState';
 import dayjs from 'dayjs';
 import type { FC } from 'react';
@@ -72,6 +72,10 @@ const MainLayoutPageProvider: FC<HeaderProviderProps> = ({ children }) => {
 	const subLogSearch = useSubscribeState<LogsSearch>({
 		search: '',
 		filters: {},
+		sort: {
+			field: 'p_timestamp',
+			order: SortOrder.DESCENDING
+		}
 	});
 	const subLogSelectedTimeRange = useSubscribeState<string>(DEFAULT_FIXED_DURATIONS.name);
 	const subRefreshInterval = useSubscribeState<number | null>(null);

--- a/src/pages/Logs/Column.tsx
+++ b/src/pages/Logs/Column.tsx
@@ -1,7 +1,7 @@
-import type { Log } from '@/@types/parseable/api/query';
+import { Log, SortOrder } from '@/@types/parseable/api/query';
 import { Box, Checkbox, Popover, Text, TextInput, Tooltip, UnstyledButton, px } from '@mantine/core';
 import { type ChangeEvent, type FC, Fragment, useTransition, useRef, useCallback, useMemo } from 'react';
-import { IconFilter, IconSearch } from '@tabler/icons-react';
+import { IconFilter, IconSearch, IconSortAscending, IconSortDescending } from '@tabler/icons-react';
 import useMountedState from '@/hooks/useMountedState';
 import { useTableColumnStyle } from './styles';
 import EmptyBox from '@/components/Empty';
@@ -17,10 +17,12 @@ type Column = {
 	getColumnFilters: (columnName: string) => Log[number][] | null;
 	appliedFilter: (columnName: string) => string[];
 	applyFilter: (columnName: string, value: string[]) => void;
+	setSorting: (order: SortOrder | null) => void;
+	fieldSortOrder: SortOrder | null
 };
 
 const Column: FC<Column> = (props) => {
-	const { columnName, getColumnFilters, appliedFilter, applyFilter } = props;
+	const { columnName, getColumnFilters, appliedFilter, applyFilter, setSorting, fieldSortOrder } = props;
 
 	// columnValues ref will always have the unfiltered data.
 	const _columnValuesRef = useRef<Log[number][] | null>(null);
@@ -87,6 +89,7 @@ const Column: FC<Column> = (props) => {
 				</Popover.Target>
 				<Popover.Dropdown>
 					<Box>
+						<SortWidget setSortOrder={setSorting} fieldSortOrder={fieldSortOrder}/>
 						<Text mb="xs">Filter by values:</Text>
 						<TextInput
 							className={searchInputStyle}
@@ -169,5 +172,39 @@ const CheckboxRow: FC<CheckboxRowProps> = (props) => {
 		</Tooltip>
 	);
 };
+
+type SortWidgetProps = {
+	setSortOrder: (order: SortOrder | null) => void;
+	fieldSortOrder: SortOrder | null;
+}
+
+const SortWidget: FC<SortWidgetProps> = (props) => {
+	const { setSortOrder, fieldSortOrder } = props;
+
+	return <>
+		<IconSortAscending
+			cursor={'pointer'}
+			onClick={() => 
+				setSortOrder(
+					fieldSortOrder === SortOrder.ASCENDING ? 
+						null 
+							: 
+						SortOrder.ASCENDING
+				)} 
+			stroke={fieldSortOrder === SortOrder.ASCENDING ? 2 : 1} 
+		/>
+		<IconSortDescending
+			cursor={'pointer'} 
+			onClick={() => 
+				setSortOrder(
+					fieldSortOrder === SortOrder.DESCENDING ? 
+						null 
+							: 
+						SortOrder.DESCENDING
+				)} 
+			stroke={fieldSortOrder === SortOrder.DESCENDING ? 2 : 1}
+		/>
+	</>
+}
 
 export default Column;

--- a/src/pages/Logs/Column.tsx
+++ b/src/pages/Logs/Column.tsx
@@ -12,6 +12,47 @@ import compare from 'just-compare';
 import { parseLogData } from '@/utils';
 import { useDisclosure } from '@mantine/hooks';
 
+type SortWidgetProps = {
+	setSortOrder: (order: SortOrder | null) => void;
+	fieldSortOrder: SortOrder | null;
+}
+
+/**
+ * Component that allows selecting sorting by a given field
+ */
+const SortWidget: FC<SortWidgetProps> = (props) => {
+	const { setSortOrder, fieldSortOrder } = props;
+	const toggleAscending = () => {
+		setSortOrder(
+			fieldSortOrder === SortOrder.ASCENDING ?
+				null
+					:
+				SortOrder.ASCENDING
+		)
+	}
+	const toggleDescending = () => {
+		setSortOrder(
+			fieldSortOrder === SortOrder.DESCENDING ?
+				null
+					:
+				SortOrder.DESCENDING
+		)
+	}
+
+	return <>
+		<IconSortAscending
+			cursor={'pointer'}
+			onClick={toggleAscending}
+			stroke={fieldSortOrder === SortOrder.ASCENDING ? 2 : 1}
+		/>
+		<IconSortDescending
+			cursor={'pointer'}
+			onClick={toggleDescending}
+			stroke={fieldSortOrder === SortOrder.DESCENDING ? 2 : 1}
+		/>
+	</>
+}
+
 type Column = {
 	columnName: string;
 	getColumnFilters: (columnName: string) => Log[number][] | null;
@@ -172,39 +213,5 @@ const CheckboxRow: FC<CheckboxRowProps> = (props) => {
 		</Tooltip>
 	);
 };
-
-type SortWidgetProps = {
-	setSortOrder: (order: SortOrder | null) => void;
-	fieldSortOrder: SortOrder | null;
-}
-
-const SortWidget: FC<SortWidgetProps> = (props) => {
-	const { setSortOrder, fieldSortOrder } = props;
-
-	return <>
-		<IconSortAscending
-			cursor={'pointer'}
-			onClick={() => 
-				setSortOrder(
-					fieldSortOrder === SortOrder.ASCENDING ? 
-						null 
-							: 
-						SortOrder.ASCENDING
-				)} 
-			stroke={fieldSortOrder === SortOrder.ASCENDING ? 2 : 1} 
-		/>
-		<IconSortDescending
-			cursor={'pointer'} 
-			onClick={() => 
-				setSortOrder(
-					fieldSortOrder === SortOrder.DESCENDING ? 
-						null 
-							: 
-						SortOrder.DESCENDING
-				)} 
-			stroke={fieldSortOrder === SortOrder.DESCENDING ? 2 : 1}
-		/>
-	</>
-}
 
 export default Column;

--- a/src/pages/Logs/LogTable.tsx
+++ b/src/pages/Logs/LogTable.tsx
@@ -84,16 +84,18 @@ const LogTable: FC = () => {
 	const sortingSetter = (columName: string) => {
 		return (order: SortOrder | null) => {
 			setQuerySearch((prev) => {
-				if (order === null) {
-					prev.sort.field = 'p_timestamp';
-					prev.sort.order = -1;
-				} else {
-					prev.sort.field = columName;
-					prev.sort.order = order;
+				const sort = {
+					field: 'p_timestamp',
+					order: SortOrder.DESCENDING
+				}
+				if (order !== null) {
+					sort.field = columName;
+					sort.order = order;
 				}
 
 				return {
-					...prev
+					...prev,
+					sort
 				}
 			})
 		}

--- a/src/pages/Logs/LogTable.tsx
+++ b/src/pages/Logs/LogTable.tsx
@@ -18,6 +18,7 @@ import Column from './Column';
 import FilterPills from './FilterPills';
 import { useHeaderContext } from '@/layouts/MainLayout/Context';
 import dayjs from 'dayjs';
+import { SortOrder } from '@/@types/parseable/api/query';
 
 const skipFields = ['p_metadata', 'p_tags'];
 
@@ -50,6 +51,7 @@ const LogTable: FC = () => {
 		loading: logsLoading,
 		error: logsError,
 		resetData: resetLogsData,
+		sort
 	} = useQueryLogs();
 
 	const appliedFilter = (key: string) => {
@@ -78,6 +80,24 @@ const LogTable: FC = () => {
 	const toggleColumn = (columnName: string, value: boolean) => {
 		setColumnToggles(new Map(columnToggles.set(columnName, value)));
 	};
+
+	const sortingSetter = (columName: string) => {
+		return (order: SortOrder | null) => {
+			setQuerySearch((prev) => {
+				if (order === null) {
+					prev.sort.field = 'p_timestamp';
+					prev.sort.order = -1;
+				} else {
+					prev.sort.field = columName;
+					prev.sort.order = order;
+				}
+
+				return {
+					...prev
+				}
+			})
+		}
+	}
 
 	const onRetry = () => {
 		const query = subLogQuery.get();
@@ -157,13 +177,15 @@ const LogTable: FC = () => {
 						appliedFilter={appliedFilter}
 						applyFilter={applyFilter}
 						getColumnFilters={getColumnFilters}
+						setSorting={sortingSetter(field.name)}
+						fieldSortOrder={sort.field === field.name ? sort.order : null}
 					/>
 				);
 			});
 		}
 
 		return null;
-	}, [logsSchema, columnToggles, logs]);
+	}, [logsSchema, columnToggles, logs, sort]);
 
 	const { classes } = useLogTableStyles();
 

--- a/src/pages/Logs/LogTable.tsx
+++ b/src/pages/Logs/LogTable.tsx
@@ -81,6 +81,9 @@ const LogTable: FC = () => {
 		setColumnToggles(new Map(columnToggles.set(columnName, value)));
 	};
 
+	/**
+	 * Function to get a setter to set sort order on a given field
+	 */
 	const sortingSetter = (columName: string) => {
 		return (order: SortOrder | null) => {
 			setQuerySearch((prev) => {


### PR DESCRIPTION
Changes:
 - Added option to sort by a given field (addresses #90)

Tested implemented functionality by opening a field filter popover and selecting one of the sorting icons

Sorts by descending order of p_timestamp by default. Selecting the currently selected sort icon resets to default option above.
