### PR TITLE
[Bugs] page change context reset, query page time range context change ,stats status duration limit

### DIFF
--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -122,9 +122,9 @@ const Navbar: FC<NavbarProps> = (props) => {
 		}
 	}, [streams]);
 
-	const handleChange = (value: string) => {
-		handleChangeWithoutRiderection(value);
-		navigate(`/${value}${currentPage}`);
+	const handleChange = (value: string,page: string = currentPage ) => {
+		handleChangeWithoutRiderection(value,page);
+		navigate(`/${value}${page}`);
 	};
 	const handleChangeWithoutRiderection = (value: string, page: string = currentPage) => {
 		setActiveStream(value);
@@ -223,8 +223,7 @@ const Navbar: FC<NavbarProps> = (props) => {
 							sx={{ paddingLeft: 53 }}
 							disabled={disableLink}
 							onClick={() => {
-								navigate(`/${activeStream}${link.pathname}`);
-								setCurrentPage(link.pathname);
+								handleChange(activeStream,link.pathname);
 							}}
 							key={link.label}
 							className={(currentPage === link.pathname && linkBtnActive) || linkBtn}

--- a/src/pages/Query/QueryCodeEditor.tsx
+++ b/src/pages/Query/QueryCodeEditor.tsx
@@ -24,7 +24,7 @@ const QueryCodeEditor: FC = () => {
 	const monacoRef = React.useRef<any>();
 	const [isSchemaOpen, setIsSchemaOpen] = useMountedState(false);
 	const [refreshInterval, setRefreshInterval] = useMountedState<number | null>(null);
-	const [currentStreamName, setCurrentStreamName] = useMountedState<string>("");
+	const [currentStreamName, setCurrentStreamName] = useMountedState<string>(subLogQuery.get().streamName);
 	const [query, setQuery] = useMountedState<string>("");
 
 	const handleEditorChange = (code: any) => {
@@ -48,7 +48,9 @@ const QueryCodeEditor: FC = () => {
 		const subQueryListener = subLogQuery.subscribe((state) => {
 			if (state.streamName) {
 				if (state.streamName !== currentStreamName) {
-					setQuery(`SELECT count(*) FROM ${state.streamName} ;`);
+					console.log(state.streamName, currentStreamName);
+					setQuery(`SELECT * FROM ${state.streamName} LIMIT 100  ; `);
+					
 					result.set('');
 				}
 				setCurrentStreamName(state.streamName);
@@ -64,7 +66,6 @@ const QueryCodeEditor: FC = () => {
 useEffect(() => {
 	if(subLogQuery.get().streamName){
 		setQuery(`SELECT * FROM ${subLogQuery.get().streamName} LIMIT 100  ; `);
-		setCurrentStreamName(subLogQuery.get().streamName);
 	}
 }, []);
 

--- a/src/pages/Stats/Status.tsx
+++ b/src/pages/Stats/Status.tsx
@@ -103,28 +103,28 @@ const Status: FC = () => {
 			startTime: now.subtract(FIXED_DURATIONS[statusFIXEDDURATIONS].milliseconds, 'milliseconds').toDate(),
 			endTime: now.toDate(),
 		};
-		getQueryData(LogQuery, `SELECT count(*) FROM ${subLogQuery.get().streamName} ;`);
+		getQueryData(LogQuery, `SELECT count(*) as count FROM ${subLogQuery.get().streamName} ;`);
 	};
 
 	useEffect(() => {
-		if (queryResult?.data[0] && queryResult?.data[0]['COUNT(UInt8(1))']) {
-			setStatus(`${queryResult?.data[0]['COUNT(UInt8(1))']} events in ${FIXED_DURATIONS[statusFIXEDDURATIONS].name}`);
+		if (queryResult?.data[0] && queryResult?.data[0]['count']) {
+			setStatus(`${queryResult?.data[0]['count']} events in ${FIXED_DURATIONS[statusFIXEDDURATIONS-1].name}`);
 			setStatusSuccess(true);
 			return;
 		}
 		if (errorQueryResult) {
-			setStatus(`Not Recieved any events in ${FIXED_DURATIONS[statusFIXEDDURATIONS - 1].name}`);
+			setStatus(`Not Recieved any events in ${FIXED_DURATIONS[statusFIXEDDURATIONS - 1].name} and error `);
 			setStatusSuccess(false);
 			return;
 		}
-		if (queryResult?.data[0] && queryResult?.data[0]['COUNT(UInt8(1))'] === 0) {
+		if (queryResult?.data[0] && queryResult?.data[0]['count'] === 0) {
 			setStatus('Loading...');
-			if (FIXED_DURATIONS.length - 1 > statusFIXEDDURATIONS) {
-				setStatusFIXEDDURATIONS(statusFIXEDDURATIONS + 1);
+			if (FIXED_DURATIONS.length  > statusFIXEDDURATIONS) {
 				getStatus();
+				setStatusFIXEDDURATIONS(statusFIXEDDURATIONS + 1);
 				return;
 			} else {
-				setStatus(`No events received ${FIXED_DURATIONS[statusFIXEDDURATIONS].name}`);
+				setStatus(`No events received ${FIXED_DURATIONS[statusFIXEDDURATIONS-1].name}`);
 				setStatusSuccess(false);
 			}
 		} else {


### PR DESCRIPTION
there are three bugs caused or new page change handler 

1 . `Navbar/index.tsx` if users change the page (not stream) it was not reseting the context .
2 . `console/queryeditor.tsx` if users change the time range it reset the query to default .
3.  `stats/index.tsx` if a stream doesn't receive event form last seven day that returns `no events received in past 2 months`