### PR TITLE
implemented useOuterClick - mantine calendar modal issue

### DIFF
--- a/src/hooks/useOuterClick.ts
+++ b/src/hooks/useOuterClick.ts
@@ -1,0 +1,21 @@
+import type { MutableRefObject } from 'react';
+import { useEffect, useRef } from 'react';
+
+export const useOuterClick = (callback: (event: any) => void): MutableRefObject<HTMLDivElement | null> => {
+	const innerRef: MutableRefObject<HTMLDivElement | null> = useRef(null);
+	useEffect(() => {
+		const handleClickOutside = (event: any) => {
+			if (innerRef.current && !(innerRef.current as any).contains(event.target)) {
+				callback(event);
+			}
+		};
+
+		document.addEventListener('click', handleClickOutside);
+
+		return () => {
+			document.removeEventListener('click', handleClickOutside);
+		};
+	}, [callback]);
+
+	return innerRef;
+};


### PR DESCRIPTION
Since there is no support to pass ref to Mantine's datepicker modal, implemented useOuterClick that ensures that the time range popover doesn't close unintentionally when the user interacts with the calendar. 