### PR TITLE
Fix: Filter builder was applying filter on removing rules

### DIFF
--- a/src/pages/Stream/components/Querier/index.tsx
+++ b/src/pages/Stream/components/Querier/index.tsx
@@ -180,7 +180,7 @@ const Querier = () => {
 
 		// trigger query fetch if the rules were updated by the remove btn on pills
 		// -----------------------------------
-		if ((!showQueryBuilder && activeMode === 'filters') || savedFilterId) {
+		if (!showQueryBuilder && (activeMode === 'filters' || savedFilterId)) {
 			if (!shouldSumbitDisabled) {
 				onFiltersApply({ isUncontrolled: true });
 			} else {

--- a/src/pages/Stream/providers/FilterProvider.tsx
+++ b/src/pages/Stream/providers/FilterProvider.tsx
@@ -160,7 +160,7 @@ const addRuleToGroup = (store: FilterStore, groupId: string) => {
 								...ruleSet.rules,
 								{ id: `rule-${generateRandomId(6)}`, field: fields[0].name, value: '', operator: '=' },
 							],
-						};
+					  };
 			}),
 		},
 	};


### PR DESCRIPTION
Previously on adding a saved filter and then removing the a condition the filter builder will close the modal and apply the remaining condition. This PR changes the flow and waits for the user to click the apply button.