### PR TITLE
Fix: On changing page offset it will always pick the first available page

### DIFF
--- a/src/pages/Stream/Views/Explore/Footer.tsx
+++ b/src/pages/Stream/Views/Explore/Footer.tsx
@@ -109,11 +109,12 @@ const Footer = (props: { loaded: boolean; hasNoData: boolean; isFetchingCount: b
 				const targetOffset = currentOffset - LOAD_LIMIT;
 				if (currentOffset < 0) return;
 
+				setLogsStore((store) => setCurrentOffset(store, targetOffset));
+
 				if (targetOffset === 0 && currentOffset > 0) {
 					// hack to initiate fetch
 					setLogsStore((store) => setCurrentPage(store, 0));
 				}
-				setLogsStore((store) => setCurrentOffset(store, targetOffset));
 			} else {
 				const targetOffset = currentOffset + LOAD_LIMIT;
 				setLogsStore((store) => setCurrentOffset(store, targetOffset));

--- a/src/pages/Stream/Views/Explore/Footer.tsx
+++ b/src/pages/Stream/Views/Explore/Footer.tsx
@@ -109,15 +109,17 @@ const Footer = (props: { loaded: boolean; hasNoData: boolean; isFetchingCount: b
 				const targetOffset = currentOffset - LOAD_LIMIT;
 				if (currentOffset < 0) return;
 
-				setLogsStore((store) => setCurrentOffset(store, targetOffset));
-
 				if (targetOffset === 0 && currentOffset > 0) {
 					// hack to initiate fetch
 					setLogsStore((store) => setCurrentPage(store, 0));
+				} else {
+					setLogsStore((store) => setCurrentPage(store, 1));
 				}
+				setLogsStore((store) => setCurrentOffset(store, targetOffset));
 			} else {
 				const targetOffset = currentOffset + LOAD_LIMIT;
 				setLogsStore((store) => setCurrentOffset(store, targetOffset));
+				setLogsStore((store) => setCurrentPage(store, 1));
 			}
 		},
 		[currentOffset],

--- a/src/pages/Stream/Views/Explore/Footer.tsx
+++ b/src/pages/Stream/Views/Explore/Footer.tsx
@@ -112,14 +112,11 @@ const Footer = (props: { loaded: boolean; hasNoData: boolean; isFetchingCount: b
 				if (targetOffset === 0 && currentOffset > 0) {
 					// hack to initiate fetch
 					setLogsStore((store) => setCurrentPage(store, 0));
-				} else {
-					setLogsStore((store) => setCurrentPage(store, 1));
 				}
 				setLogsStore((store) => setCurrentOffset(store, targetOffset));
 			} else {
 				const targetOffset = currentOffset + LOAD_LIMIT;
 				setLogsStore((store) => setCurrentOffset(store, targetOffset));
-				setLogsStore((store) => setCurrentPage(store, 1));
 			}
 		},
 		[currentOffset],

--- a/src/pages/Stream/providers/LogsProvider.tsx
+++ b/src/pages/Stream/providers/LogsProvider.tsx
@@ -584,7 +584,6 @@ const setCurrentOffset = (store: LogsStore, currentOffset: number) => {
 	return {
 		tableOpts: {
 			...store.tableOpts,
-			currentPage: 1,
 			currentOffset,
 		},
 	};

--- a/src/pages/Stream/providers/LogsProvider.tsx
+++ b/src/pages/Stream/providers/LogsProvider.tsx
@@ -584,6 +584,7 @@ const setCurrentOffset = (store: LogsStore, currentOffset: number) => {
 	return {
 		tableOpts: {
 			...store.tableOpts,
+			currentPage: 1,
 			currentOffset,
 		},
 	};

--- a/src/pages/Stream/providers/LogsProvider.tsx
+++ b/src/pages/Stream/providers/LogsProvider.tsx
@@ -533,7 +533,7 @@ export const isJqSearch = (value: string) => {
 const setLogData = (store: LogsStore, data: Log[], headers: string[], jqFilteredData?: Log[]) => {
 	const { data: existingData, tableOpts, viewMode } = store;
 	const isJsonView = viewMode === 'json';
-	const currentPage = tableOpts.currentPage === 0 ? 1 : tableOpts.currentPage;
+	const currentPage = 1;
 	const filteredData =
 		isJsonView && !_.isEmpty(tableOpts.instantSearchValue)
 			? isJqSearch(tableOpts.instantSearchValue)
@@ -546,7 +546,7 @@ const setLogData = (store: LogsStore, data: Log[], headers: string[], jqFiltered
 			...store.tableOpts,
 			...(newPageSlice ? { pageData: newPageSlice } : {}),
 			headers,
-			currentPage: 1,
+			currentPage,
 			totalPages: getTotalPages(filteredData, tableOpts.perPage),
 		},
 		data: { ...existingData, rawData: data, filteredData: filteredData },

--- a/src/pages/Stream/providers/LogsProvider.tsx
+++ b/src/pages/Stream/providers/LogsProvider.tsx
@@ -546,7 +546,7 @@ const setLogData = (store: LogsStore, data: Log[], headers: string[], jqFiltered
 			...store.tableOpts,
 			...(newPageSlice ? { pageData: newPageSlice } : {}),
 			headers,
-			currentPage,
+			currentPage: 1,
 			totalPages: getTotalPages(filteredData, tableOpts.perPage),
 		},
 		data: { ...existingData, rawData: data, filteredData: filteredData },


### PR DESCRIPTION
On changing offset the page was not set to the first available. This PR makes sure the previous selected page is not set for the newly fetched logs