### PR TITLE
fix : Reset table filters on stream change

### DIFF
--- a/src/pages/Stream/providers/LogsProvider.tsx
+++ b/src/pages/Stream/providers/LogsProvider.tsx
@@ -658,6 +658,7 @@ const setCleanStoreForStreamChange = (store: LogsStore) => {
 			currentPage: 0,
 			currentOffset: 0,
 			totalPages: 0,
+			filters: {},
 		},
 		...updatedTimeRange,
 		alerts,


### PR DESCRIPTION
### Description
The current build of console stores the filters even when the stream is changed. This PR fixes the issue by reseting the applied filters