### PR TITLE
 Fix: Multiple queries were fired

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ build.zip
 /coverage
 
 
+.vercel

--- a/.gitignore
+++ b/.gitignore
@@ -51,4 +51,3 @@ build.zip
 /coverage
 
 
-.vercel

--- a/src/hooks/useQueryResult.tsx
+++ b/src/hooks/useQueryResult.tsx
@@ -81,7 +81,7 @@ export const useFetchCount = () => {
 		},
 		refetchOnWindowFocus: false,
 		retry: false,
-		enabled: currentStream !== null,
+		enabled: false,
 	});
 
 	return {

--- a/src/hooks/useQueryResult.tsx
+++ b/src/hooks/useQueryResult.tsx
@@ -81,6 +81,7 @@ export const useFetchCount = () => {
 		},
 		refetchOnWindowFocus: false,
 		retry: false,
+		enabled: currentStream !== null,
 	});
 
 	return {

--- a/src/hooks/useQueryResult.tsx
+++ b/src/hooks/useQueryResult.tsx
@@ -81,7 +81,6 @@ export const useFetchCount = () => {
 		},
 		refetchOnWindowFocus: false,
 		retry: false,
-		enabled: false,
 	});
 
 	return {

--- a/src/pages/Stream/Views/Explore/useLogsFetcher.ts
+++ b/src/pages/Stream/Views/Explore/useLogsFetcher.ts
@@ -18,7 +18,7 @@ const useLogsFetcher = (props: { schemaLoading: boolean }) => {
 	const showTable = hasContentLoaded && !hasNoData && !errorMessage;
 
 	useEffect(() => {
-		setLogsStore(setCleanStoreForStreamChange);
+		setLogsStore((store) => setCleanStoreForStreamChange(store));
 	}, [currentStream]);
 
 	useEffect(() => {

--- a/src/pages/Stream/Views/Explore/useLogsFetcher.ts
+++ b/src/pages/Stream/Views/Explore/useLogsFetcher.ts
@@ -10,19 +10,17 @@ const useLogsFetcher = (props: { schemaLoading: boolean }) => {
 	const { schemaLoading } = props;
 	const [currentStream] = useAppStore((store) => store.currentStream);
 	const [{ tableOpts }, setLogsStore] = useLogsStore((store) => store);
+
 	useMemo(() => {
 		setLogsStore(setCleanLogStoreForStreamChange);
 	}, [currentStream]);
+
 	const { currentOffset, currentPage, pageData } = tableOpts;
 	const { getQueryData, loading: logsLoading, error: errorMessage } = useQueryLogs();
 	const { refetchCount, isCountLoading, isCountRefetching } = useFetchCount();
 	const hasContentLoaded = schemaLoading === false && logsLoading === false;
 	const hasNoData = hasContentLoaded && !errorMessage && pageData.length === 0;
 	const showTable = hasContentLoaded && !hasNoData && !errorMessage;
-
-	// useEffect(() => {
-	// 	setLogsStore(setCleanLogStoreForStreamChange);
-	// }, [currentStream]);
 
 	useEffect(() => {
 		if (currentPage === 0 && currentOffset === 0) {

--- a/src/pages/Stream/Views/Explore/useLogsFetcher.ts
+++ b/src/pages/Stream/Views/Explore/useLogsFetcher.ts
@@ -9,7 +9,7 @@ const { setCleanStoreForStreamChange } = logsStoreReducers;
 const useLogsFetcher = (props: { schemaLoading: boolean }) => {
 	const { schemaLoading } = props;
 	const [currentStream] = useAppStore((store) => store.currentStream);
-	const [{ tableOpts, timeRange }, setLogsStore] = useLogsStore((store) => store);
+	const [{ tableOpts }, setLogsStore] = useLogsStore((store) => store);
 	const { currentOffset, currentPage, pageData } = tableOpts;
 	const { getQueryData, loading: logsLoading, error: errorMessage } = useQueryLogs();
 	const { refetchCount, isCountLoading, isCountRefetching } = useFetchCount();
@@ -26,7 +26,7 @@ const useLogsFetcher = (props: { schemaLoading: boolean }) => {
 			getQueryData();
 			refetchCount();
 		}
-	}, [currentPage, currentStream, timeRange]);
+	}, [currentPage, currentStream]);
 
 	useEffect(() => {
 		if (currentOffset !== 0 && currentPage !== 0) {

--- a/src/pages/Stream/Views/Explore/useLogsFetcher.ts
+++ b/src/pages/Stream/Views/Explore/useLogsFetcher.ts
@@ -1,5 +1,5 @@
 import { useAppStore } from '@/layouts/MainLayout/providers/AppProvider';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useLogsStore, logsStoreReducers } from '../../providers/LogsProvider';
 import { useQueryLogs } from '@/hooks/useQueryLogs';
 import { useFetchCount } from '@/hooks/useQueryResult';
@@ -10,6 +10,9 @@ const useLogsFetcher = (props: { schemaLoading: boolean }) => {
 	const { schemaLoading } = props;
 	const [currentStream] = useAppStore((store) => store.currentStream);
 	const [{ tableOpts }, setLogsStore] = useLogsStore((store) => store);
+	useMemo(() => {
+		setLogsStore(setCleanLogStoreForStreamChange);
+	}, [currentStream]);
 	const { currentOffset, currentPage, pageData } = tableOpts;
 	const { getQueryData, loading: logsLoading, error: errorMessage } = useQueryLogs();
 	const { refetchCount, isCountLoading, isCountRefetching } = useFetchCount();
@@ -17,9 +20,9 @@ const useLogsFetcher = (props: { schemaLoading: boolean }) => {
 	const hasNoData = hasContentLoaded && !errorMessage && pageData.length === 0;
 	const showTable = hasContentLoaded && !hasNoData && !errorMessage;
 
-	useEffect(() => {
-		setLogsStore(setCleanLogStoreForStreamChange);
-	}, [currentStream]);
+	// useEffect(() => {
+	// 	setLogsStore(setCleanLogStoreForStreamChange);
+	// }, [currentStream]);
 
 	useEffect(() => {
 		if (currentPage === 0 && currentOffset === 0) {

--- a/src/pages/Stream/Views/Explore/useLogsFetcher.ts
+++ b/src/pages/Stream/Views/Explore/useLogsFetcher.ts
@@ -4,7 +4,7 @@ import { useLogsStore, logsStoreReducers } from '../../providers/LogsProvider';
 import { useQueryLogs } from '@/hooks/useQueryLogs';
 import { useFetchCount } from '@/hooks/useQueryResult';
 
-const { setCleanStoreForStreamChange } = logsStoreReducers;
+const { setCleanLogStoreForStreamChange } = logsStoreReducers;
 
 const useLogsFetcher = (props: { schemaLoading: boolean }) => {
 	const { schemaLoading } = props;
@@ -18,7 +18,7 @@ const useLogsFetcher = (props: { schemaLoading: boolean }) => {
 	const showTable = hasContentLoaded && !hasNoData && !errorMessage;
 
 	useEffect(() => {
-		setLogsStore(setCleanStoreForStreamChange);
+		setLogsStore(setCleanLogStoreForStreamChange);
 	}, [currentStream]);
 
 	useEffect(() => {

--- a/src/pages/Stream/Views/Explore/useLogsFetcher.ts
+++ b/src/pages/Stream/Views/Explore/useLogsFetcher.ts
@@ -18,7 +18,7 @@ const useLogsFetcher = (props: { schemaLoading: boolean }) => {
 	const showTable = hasContentLoaded && !hasNoData && !errorMessage;
 
 	useEffect(() => {
-		setLogsStore((store) => setCleanStoreForStreamChange(store));
+		setLogsStore(setCleanStoreForStreamChange);
 	}, [currentStream]);
 
 	useEffect(() => {

--- a/src/pages/Stream/providers/LogsProvider.tsx
+++ b/src/pages/Stream/providers/LogsProvider.tsx
@@ -273,7 +273,7 @@ type LogsStoreReducers = {
 	makeExportData: (data: Log[], headers: string[], type: string) => Log[];
 	setRetention: (store: LogsStore, retention: { description: string; duration: string }) => ReducerOutput;
 
-	setCleanStoreForStreamChange: (store: LogsStore) => ReducerOutput;
+	setCleanLogStoreForStreamChange: (store: LogsStore) => ReducerOutput;
 	updateSavedFilterId: (store: LogsStore, savedFilterId: string | null) => ReducerOutput;
 	setInstantSearchValue: (store: LogsStore, value: string) => ReducerOutput;
 	applyInstantSearch: (store: LogsStore) => ReducerOutput;
@@ -643,28 +643,13 @@ const getCleanStoreForRefetch = (store: LogsStore) => {
 	};
 };
 
-const setCleanStoreForStreamChange = (_store: LogsStore) => {
-	// const { tableOpts, timeRange, alerts } = store;
-	// const { interval, type } = timeRange;
-	// const duration = _.find(FIXED_DURATIONS, (duration) => duration.milliseconds === timeRange.interval);
-	// const updatedTimeRange = interval && type === 'fixed' ? { timeRange: getDefaultTimeRange(duration) } : { timeRange };
-	// return {
-	// 	...initialState,
-	// 	tableOpts: {
-	// 		...tableOpts,
-	// 		pageData: [],
-	// 		totalCount: 0,
-	// 		displayedCount: 0,
-	// 		currentPage: 0,
-	// 		currentOffset: 0,
-	// 		totalPages: 0,
-	// 		filters: {},
-	// 	},
-	// 	alerts,
-	// 	...updatedTimeRange,
-	// };
+const setCleanLogStoreForStreamChange = (store: LogsStore) => {
+	const { timeRange } = store;
+	const { interval, type } = timeRange;
+	const duration = _.find(FIXED_DURATIONS, (duration) => duration.milliseconds === timeRange.interval);
+	const updatedTimeRange = interval && type === 'fixed' ? { timeRange: getDefaultTimeRange(duration) } : { timeRange };
 
-	return initialState;
+	return { ...initialState, timeRange: updatedTimeRange.timeRange };
 };
 
 const applyCustomQuery = (
@@ -910,7 +895,7 @@ const logsStoreReducers: LogsStoreReducers = {
 	setSelectedLog,
 	makeExportData,
 	setRetention,
-	setCleanStoreForStreamChange,
+	setCleanLogStoreForStreamChange,
 	toggleSideBar,
 	updateSavedFilterId,
 	setInstantSearchValue,

--- a/src/pages/Stream/providers/LogsProvider.tsx
+++ b/src/pages/Stream/providers/LogsProvider.tsx
@@ -663,6 +663,7 @@ const setCleanStoreForStreamChange = (_store: LogsStore) => {
 	// 	alerts,
 	// 	...updatedTimeRange,
 	// };
+
 	return initialState;
 };
 

--- a/src/pages/Stream/providers/LogsProvider.tsx
+++ b/src/pages/Stream/providers/LogsProvider.tsx
@@ -643,11 +643,11 @@ const getCleanStoreForRefetch = (store: LogsStore) => {
 	};
 };
 
-const setCleanStoreForStreamChange = (store: LogsStore) => {
-	const { tableOpts, timeRange, alerts } = store;
-	const { interval, type } = timeRange;
-	const duration = _.find(FIXED_DURATIONS, (duration) => duration.milliseconds === timeRange.interval);
-	const updatedTimeRange = interval && type === 'fixed' ? { timeRange: getDefaultTimeRange(duration) } : { timeRange };
+const setCleanStoreForStreamChange = (_store: LogsStore) => {
+	// const { tableOpts, timeRange, alerts } = store;
+	// const { interval, type } = timeRange;
+	// const duration = _.find(FIXED_DURATIONS, (duration) => duration.milliseconds === timeRange.interval);
+	// const updatedTimeRange = interval && type === 'fixed' ? { timeRange: getDefaultTimeRange(duration) } : { timeRange };
 	// return {
 	// 	...initialState,
 	// 	tableOpts: {

--- a/src/pages/Stream/providers/LogsProvider.tsx
+++ b/src/pages/Stream/providers/LogsProvider.tsx
@@ -649,7 +649,7 @@ const setCleanLogStoreForStreamChange = (store: LogsStore) => {
 	const duration = _.find(FIXED_DURATIONS, (duration) => duration.milliseconds === timeRange.interval);
 	const updatedTimeRange = interval && type === 'fixed' ? { timeRange: getDefaultTimeRange(duration) } : { timeRange };
 
-	return { ...initialState, timeRange: updatedTimeRange.timeRange };
+	return { ...initialState, ...updatedTimeRange };
 };
 
 const applyCustomQuery = (

--- a/src/pages/Stream/providers/LogsProvider.tsx
+++ b/src/pages/Stream/providers/LogsProvider.tsx
@@ -644,12 +644,29 @@ const getCleanStoreForRefetch = (store: LogsStore) => {
 };
 
 const setCleanLogStoreForStreamChange = (store: LogsStore) => {
-	const { timeRange } = store;
+	const { tableOpts, timeRange, alerts } = store;
 	const { interval, type } = timeRange;
 	const duration = _.find(FIXED_DURATIONS, (duration) => duration.milliseconds === timeRange.interval);
 	const updatedTimeRange = interval && type === 'fixed' ? { timeRange: getDefaultTimeRange(duration) } : { timeRange };
 
-	return { ...initialState, ...updatedTimeRange };
+	return {
+		...initialState,
+		tableOpts: {
+			...tableOpts,
+			pageData: [],
+			totalCount: 0,
+			displayedCount: 0,
+			currentPage: 0,
+			currentOffset: 0,
+			totalPages: 0,
+			orderedHeaders: [],
+			disabledColumns: [],
+			pinnedColumns: [],
+			filters: {},
+		},
+		...updatedTimeRange,
+		alerts,
+	};
 };
 
 const applyCustomQuery = (

--- a/src/pages/Stream/providers/LogsProvider.tsx
+++ b/src/pages/Stream/providers/LogsProvider.tsx
@@ -648,21 +648,22 @@ const setCleanStoreForStreamChange = (store: LogsStore) => {
 	const { interval, type } = timeRange;
 	const duration = _.find(FIXED_DURATIONS, (duration) => duration.milliseconds === timeRange.interval);
 	const updatedTimeRange = interval && type === 'fixed' ? { timeRange: getDefaultTimeRange(duration) } : { timeRange };
-	return {
-		...initialState,
-		tableOpts: {
-			...tableOpts,
-			pageData: [],
-			totalCount: 0,
-			displayedCount: 0,
-			currentPage: 0,
-			currentOffset: 0,
-			totalPages: 0,
-			filters: {},
-		},
-		...updatedTimeRange,
-		alerts,
-	};
+	// return {
+	// 	...initialState,
+	// 	tableOpts: {
+	// 		...tableOpts,
+	// 		pageData: [],
+	// 		totalCount: 0,
+	// 		displayedCount: 0,
+	// 		currentPage: 0,
+	// 		currentOffset: 0,
+	// 		totalPages: 0,
+	// 		filters: {},
+	// 	},
+	// 	alerts,
+	// 	...updatedTimeRange,
+	// };
+	return initialState;
 };
 
 const applyCustomQuery = (


### PR DESCRIPTION
### Issue 
Multiple Queries were being fired and Log table time range is incorrect 
### Addressing the footer multiple query call in this PR

**Explanation**
If a user opens console and halts in the home page for a while the time range passed for fetch functions are incorrect and the Count fetch functions is fired twice for due to the duplication of timeRange object

**Solution**
The cleaning of the log store is done by a useEffect callback which executes the function after the component is rendered. This is changed so that the cleaning of the logsStore is done before the query is fired