### PR TITLE
Added filter_query to filter builder

### DIFF
--- a/src/@types/parseable/api/savedFilters.ts
+++ b/src/@types/parseable/api/savedFilters.ts
@@ -22,7 +22,6 @@ export type CreateSavedFilterType = {
 	query: {
 		filter_type: 'sql' | 'builder';
 		filter_query: string;
-		filter_builder?: QueryType;
 	};
 	time_filter: null | {
 		from: string;

--- a/src/@types/parseable/api/savedFilters.ts
+++ b/src/@types/parseable/api/savedFilters.ts
@@ -7,7 +7,7 @@ export type SavedFilterType = {
 	filter_id: string;
 	query: {
 		filter_type: 'sql' | 'builder';
-		filter_query: string;
+		filter_query?: string;
 		filter_builder?: QueryType;
 	};
 	time_filter: null | {

--- a/src/@types/parseable/api/savedFilters.ts
+++ b/src/@types/parseable/api/savedFilters.ts
@@ -7,7 +7,7 @@ export type SavedFilterType = {
 	filter_id: string;
 	query: {
 		filter_type: 'sql' | 'builder';
-		filter_query?: string;
+		filter_query: string;
 		filter_builder?: QueryType;
 	};
 	time_filter: null | {
@@ -21,7 +21,7 @@ export type CreateSavedFilterType = {
 	filter_name: string;
 	query: {
 		filter_type: 'sql' | 'builder';
-		filter_query?: string;
+		filter_query: string;
 		filter_builder?: QueryType;
 	};
 	time_filter: null | {

--- a/src/hooks/useSavedFilters.tsx
+++ b/src/hooks/useSavedFilters.tsx
@@ -26,7 +26,10 @@ const useSavedFiltersQuery = () => {
 	);
 
 	const { mutate: updateSavedFilters, isLoading: isUpdating } = useMutation(
-		(data: { filter: SavedFilterType; onSuccess?: () => void }) => putSavedFilters(data.filter.filter_id, data.filter),
+		(data: { filter: SavedFilterType; onSuccess?: () => void }) => {
+			data.filter.query = _.omit(data.filter.query, 'filter_builder');
+			return putSavedFilters(data.filter.filter_id, data.filter);
+		},
 		{
 			onSuccess: (_data, variables) => {
 				variables.onSuccess && variables.onSuccess();

--- a/src/hooks/useSavedFilters.tsx
+++ b/src/hooks/useSavedFilters.tsx
@@ -27,6 +27,7 @@ const useSavedFiltersQuery = () => {
 
 	const { mutate: updateSavedFilters, isLoading: isUpdating } = useMutation(
 		(data: { filter: SavedFilterType; onSuccess?: () => void }) => {
+			// filter_builder will be deleted only for new filters.
 			if (_.has(data.filter.query, 'filter_builder')) {
 				data.filter.query = _.omit(data.filter.query, 'filter_builder');
 			}

--- a/src/hooks/useSavedFilters.tsx
+++ b/src/hooks/useSavedFilters.tsx
@@ -27,7 +27,9 @@ const useSavedFiltersQuery = () => {
 
 	const { mutate: updateSavedFilters, isLoading: isUpdating } = useMutation(
 		(data: { filter: SavedFilterType; onSuccess?: () => void }) => {
-			data.filter.query = _.omit(data.filter.query, 'filter_builder');
+			if (_.has(data.filter.query, 'filter_builder')) {
+				data.filter.query = _.omit(data.filter.query, 'filter_builder');
+			}
 			return putSavedFilters(data.filter.filter_id, data.filter);
 		},
 		{

--- a/src/pages/Stream/components/Querier/FilterQueryBuilder.tsx
+++ b/src/pages/Stream/components/Querier/FilterQueryBuilder.tsx
@@ -118,15 +118,15 @@ const CombinatorToggle = (props: CombinatorToggleType) => {
 		<Box className={classes.toggleBtnContainer}>
 			<Text
 				style={{ fontSize: '0.6rem' }}
-				className={!isOrSelected ? activeBtnClass : inActiveBtnClass}
-				onClick={() => onCombinatorChange('and')}>
-				AND
-			</Text>
-			<Text
-				style={{ fontSize: '0.6rem' }}
 				className={isOrSelected ? activeBtnClass : inActiveBtnClass}
 				onClick={() => onCombinatorChange('or')}>
 				OR
+			</Text>
+			<Text
+				style={{ fontSize: '0.6rem' }}
+				className={!isOrSelected ? activeBtnClass : inActiveBtnClass}
+				onClick={() => onCombinatorChange('and')}>
+				AND
 			</Text>
 		</Box>
 	);

--- a/src/pages/Stream/components/Querier/FilterQueryBuilder.tsx
+++ b/src/pages/Stream/components/Querier/FilterQueryBuilder.tsx
@@ -118,15 +118,15 @@ const CombinatorToggle = (props: CombinatorToggleType) => {
 		<Box className={classes.toggleBtnContainer}>
 			<Text
 				style={{ fontSize: '0.6rem' }}
-				className={isOrSelected ? activeBtnClass : inActiveBtnClass}
-				onClick={() => onCombinatorChange('or')}>
-				OR
-			</Text>
-			<Text
-				style={{ fontSize: '0.6rem' }}
 				className={!isOrSelected ? activeBtnClass : inActiveBtnClass}
 				onClick={() => onCombinatorChange('and')}>
 				AND
+			</Text>
+			<Text
+				style={{ fontSize: '0.6rem' }}
+				className={isOrSelected ? activeBtnClass : inActiveBtnClass}
+				onClick={() => onCombinatorChange('or')}>
+				OR
 			</Text>
 		</Box>
 	);

--- a/src/pages/Stream/components/Querier/SaveFilterModal.tsx
+++ b/src/pages/Stream/components/Querier/SaveFilterModal.tsx
@@ -35,7 +35,6 @@ const sanitizeFilterItem = (formObject: FormObjectType): SavedFilterType => {
 
 const SaveFilterModal = () => {
 	const [isSaveFiltersModalOpen, setFilterStore] = useFilterStore((store) => store.isSaveFiltersModalOpen);
-	const [appliedQuery] = useFilterStore((store) => store.appliedQuery);
 	const [activeSavedFilters] = useAppStore((store) => store.activeSavedFilters);
 	const [formObject, setFormObject] = useState<FormObjectType | null>(null);
 	const [currentStream] = useAppStore((store) => store.currentStream);
@@ -70,7 +69,6 @@ const SaveFilterModal = () => {
 				query: {
 					filter_type: isSqlMode ? 'sql' : 'builder',
 					filter_query: custSearchQuery,
-					...(!isSqlMode && { filter_builder: appliedQuery }),
 				},
 				time_filter: {
 					from: timeRange.startTime.toISOString(),

--- a/src/pages/Stream/components/Querier/SaveFilterModal.tsx
+++ b/src/pages/Stream/components/Querier/SaveFilterModal.tsx
@@ -22,14 +22,7 @@ interface FormObjectType extends Omit<SavedFilterType, 'filter_id' | 'version'> 
 }
 
 const sanitizeFilterItem = (formObject: FormObjectType): SavedFilterType => {
-	const {
-		stream_name,
-		filter_name,
-		filter_id = '',
-		query,
-		selectedTimeRangeOption,
-		version = '',
-	} = formObject;
+	const { stream_name, filter_name, filter_id = '', query, selectedTimeRangeOption, version = '' } = formObject;
 	return {
 		filter_id,
 		version,
@@ -76,7 +69,8 @@ const SaveFilterModal = () => {
 				filter_name: '',
 				query: {
 					filter_type: isSqlMode ? 'sql' : 'builder',
-					...(isSqlMode ? { filter_query: custSearchQuery } : { filter_builder: appliedQuery }),
+					filter_query: custSearchQuery,
+					...(!isSqlMode && { filter_builder: appliedQuery }),
 				},
 				time_filter: {
 					from: timeRange.startTime.toISOString(),

--- a/src/pages/Stream/hooks/useParamsController.ts
+++ b/src/pages/Stream/hooks/useParamsController.ts
@@ -165,12 +165,12 @@ const useParamsController = () => {
 			setLogsStore((store) => setPerPage(store, _.toNumber(presentParams.rows)));
 		}
 
-		if (storeAsParams.query !== presentParams.query) {
-			setLogsStore((store) => setCustQuerySearchState(store, presentParams.query, presentParams.filterType));
+		if (storeAsParams.query !== presentParams.query && !_.isEmpty(presentParams.query)) {
 			if (presentParams.filterType === 'filters')
 				setFilterStore((store) =>
 					applySavedFilters(store, generateQueryBuilderASTFromSQL(presentParams.query) as QueryType),
 				);
+			setLogsStore((store) => setCustQuerySearchState(store, presentParams.query, presentParams.filterType));
 		}
 		syncTimeRangeToStore(storeAsParams, presentParams);
 	}, [searchParams]);

--- a/src/pages/Stream/hooks/useParamsController.ts
+++ b/src/pages/Stream/hooks/useParamsController.ts
@@ -7,8 +7,7 @@ import dayjs from 'dayjs';
 import timeRangeUtils from '@/utils/timeRangeUtils';
 import moment from 'moment-timezone';
 import { filterStoreReducers, QueryType, useFilterStore } from '../providers/FilterProvider';
-import { parseSQLWithIDs } from '../utils';
-
+import { generateQueryBuilderASTFromSQL } from '../utils';
 
 const { getRelativeStartAndEndDate, formatDateWithTimezone, getLocalTimezone } = timeRangeUtils;
 const { setTimeRange, onToggleView, setPerPage, setCustQuerySearchState } = logsStoreReducers;
@@ -68,7 +67,7 @@ const storeToParamsObj = (opts: {
 		rows,
 		page,
 		query,
-		filterType,
+		filterType: query ? filterType : '',
 	};
 	return _.pickBy(params, (val, key) => !_.isEmpty(val) && _.includes(keys, key));
 };
@@ -117,7 +116,9 @@ const useParamsController = () => {
 		if (storeAsParams.query !== presentParams.query) {
 			setLogsStore((store) => setCustQuerySearchState(store, presentParams.query, presentParams.filterType));
 			if (presentParams.filterType === 'filters')
-				setFilterStore((store) => applySavedFilters(store, parseSQLWithIDs(presentParams.query) as QueryType));
+				setFilterStore((store) =>
+					applySavedFilters(store, generateQueryBuilderASTFromSQL(presentParams.query) as QueryType),
+				);
 		}
 		syncTimeRangeToStore(storeAsParams, presentParams);
 		setStoreSynced(true);
@@ -167,7 +168,9 @@ const useParamsController = () => {
 		if (storeAsParams.query !== presentParams.query) {
 			setLogsStore((store) => setCustQuerySearchState(store, presentParams.query, presentParams.filterType));
 			if (presentParams.filterType === 'filters')
-				setFilterStore((store) => applySavedFilters(store, parseSQLWithIDs(presentParams.query) as QueryType));
+				setFilterStore((store) =>
+					applySavedFilters(store, generateQueryBuilderASTFromSQL(presentParams.query) as QueryType),
+				);
 		}
 		syncTimeRangeToStore(storeAsParams, presentParams);
 	}, [searchParams]);

--- a/src/pages/Stream/providers/LogsProvider.tsx
+++ b/src/pages/Stream/providers/LogsProvider.tsx
@@ -248,7 +248,7 @@ type LogsStoreReducers = {
 	resetQuickFilters: (store: LogsStore) => ReducerOutput;
 	streamChangeCleanup: (store: LogsStore) => ReducerOutput;
 	toggleQueryBuilder: (store: LogsStore, val?: boolean) => ReducerOutput;
-	setCustQuerySearchState: (store: LogsStore, query: string) => ReducerOutput;
+	setCustQuerySearchState: (store: LogsStore, query: string, viewMode: string) => ReducerOutput;
 	resetCustQuerySearchState: (store: LogsStore) => ReducerOutput;
 	toggleCustQuerySearchViewMode: (store: LogsStore, targetMode: 'sql' | 'filters') => ReducerOutput;
 	toggleDeleteModal: (store: LogsStore, val?: boolean) => ReducerOutput;
@@ -455,7 +455,7 @@ const toggleQueryBuilder = (store: LogsStore, val?: boolean) => {
 	};
 };
 
-const setCustQuerySearchState = (store: LogsStore, query: string) => {
+const setCustQuerySearchState = (store: LogsStore, query: string, viewMode: string) => {
 	const { timeRange } = store;
 	return {
 		custQuerySearchState: {
@@ -463,8 +463,8 @@ const setCustQuerySearchState = (store: LogsStore, query: string) => {
 			savedFilterId: null,
 			isQuerySearchActive: true,
 			custSearchQuery: query,
-			viewMode: 'sql',
-			activeMode: 'sql' as 'sql',
+			viewMode,
+			activeMode: viewMode === 'filters' ? ('filters' as 'filters') : ('sql' as 'sql'),
 		},
 		...getCleanStoreForRefetch(store),
 		timeRange,

--- a/src/pages/Stream/utils.ts
+++ b/src/pages/Stream/utils.ts
@@ -1,6 +1,8 @@
 import { Log } from '@/@types/parseable/api/query';
 import { LogStreamSchemaData } from '@/@types/parseable/api/stream';
 import { columnsToSkip } from './providers/LogsProvider';
+import { parseSQL } from 'react-querybuilder';
+import { QueryType, RuleGroupTypeOverride, RuleTypeOverride } from './providers/FilterProvider';
 
 export const getPageSlice = (page = 1, perPage: number, data: Log[]) => {
 	const firstPageIndex = (page - 1) * perPage;
@@ -8,10 +10,33 @@ export const getPageSlice = (page = 1, perPage: number, data: Log[]) => {
 	return data ? data.slice(firstPageIndex, lastPageIndex) : [];
 };
 
+export const parseSQLWithIDs = (sqlString: string) => {
+	const parsedQuery = parseSQL(sqlString) as QueryType;
+
+	function isRuleGroup(rule: RuleTypeOverride | RuleGroupTypeOverride): rule is RuleGroupTypeOverride {
+		return 'combinator' in rule && 'rules' in rule;
+	}
+
+	function addIds(query: QueryType | RuleGroupTypeOverride) {
+		if (Array.isArray(query.rules)) {
+			query.rules.forEach((rule) => {
+				rule.id = 'rule-' + Math.random();
+
+				if (isRuleGroup(rule)) {
+					addIds(rule);
+				}
+			});
+		}
+	}
+
+	addIds(parsedQuery);
+	return parsedQuery;
+};
+
 export const makeHeadersFromSchema = (schema: LogStreamSchemaData | null): string[] => {
 	if (schema) {
-		const { fields } = schema;
-		return fields.map((field) => field.name);
+	const { fields } = schema;
+	return fields.map((field) => field.name);
 	} else {
 		return [];
 	}

--- a/src/pages/Stream/utils.ts
+++ b/src/pages/Stream/utils.ts
@@ -10,7 +10,7 @@ export const getPageSlice = (page = 1, perPage: number, data: Log[]) => {
 	return data ? data.slice(firstPageIndex, lastPageIndex) : [];
 };
 
-export const parseSQLWithIDs = (sqlString: string) => {
+export const generateQueryBuilderASTFromSQL = (sqlString: string) => {
 	const parsedQuery = parseSQL(sqlString) as QueryType;
 
 	function isRuleGroup(rule: RuleTypeOverride | RuleGroupTypeOverride): rule is RuleGroupTypeOverride {
@@ -20,7 +20,7 @@ export const parseSQLWithIDs = (sqlString: string) => {
 	function addIds(query: QueryType | RuleGroupTypeOverride) {
 		if (Array.isArray(query.rules)) {
 			query.rules.forEach((rule) => {
-				rule.id = 'rule-' + Math.random();
+				rule.id = `rule-${Math.random()}`;
 
 				if (isRuleGroup(rule)) {
 					addIds(rule);
@@ -35,8 +35,8 @@ export const parseSQLWithIDs = (sqlString: string) => {
 
 export const makeHeadersFromSchema = (schema: LogStreamSchemaData | null): string[] => {
 	if (schema) {
-	const { fields } = schema;
-	return fields.map((field) => field.name);
+		const { fields } = schema;
+		return fields.map((field) => field.name);
 	} else {
 		return [];
 	}


### PR DESCRIPTION
Added `filter_query` to all types of filters.

Testing Scenarios:
1. When the query is present in the query parameter, and the page is refreshed:
Current Behavior: The query is applied but it shows filter type as SQL
Expected Behavior: The query should be applied with appropriate filter type view in the filter section.
2. When a filter is saved:
Current Behavior: filter_builder is being sent in the payload.
Expected Behavior: `filter_builder` will not be sent, instead `filter_query` will have the query.
3. When a filter is saved:
Current Behavior: `filter_builder` is being sent in the payload.
Expected Behavior: `filter_builder` will not be sent, instead `filter_query` will have the query.
4. When a saved filter is applied:
Current Behavior: The filter query  is applied but it always shows the filter view as SQL mode.
Expected Behavior: The filter should be applied as per the filter type and the respective view should be showed in the filter bar.
5. Editing a  saved filter:
Current Behavior: `filter_builder` field is sent as per the `filter_type` in the PUT call
Expected Behavior: `filter_builder` field will not be sent in the PUT call
6. New URL query parameter on filter application:
Expected Behavior: A new URL query parameter should be added to represent `filter_type` when a filter is applied, to track and maintain the filter type within the URL.