### PR TITLE
feat: Collapse feature for LogTable sidebar.

### DIFF
--- a/src/pages/Stream/Views/Explore/LogsViewConfig.tsx
+++ b/src/pages/Stream/Views/Explore/LogsViewConfig.tsx
@@ -1,37 +1,20 @@
 import { LOGS_CONFIG_SIDEBAR_WIDTH } from '@/constants/theme';
-import {
-	Box,
-	Checkbox,
-	Divider,
-	Group,
-	ScrollArea,
-	Select,
-	Skeleton,
-	Stack,
-	Text,
-	TextInput,
-	Tooltip,
-} from '@mantine/core';
+import { Checkbox, Divider, Group, ScrollArea, Select, Skeleton, Stack, Text, TextInput, Tooltip } from '@mantine/core';
 import classes from '../../styles/LogsViewConfig.module.css';
-import { useStreamStore } from '../../providers/StreamProvider';
+import { streamStoreReducers, useStreamStore } from '../../providers/StreamProvider';
 import _ from 'lodash';
 import { Field } from '@/@types/parseable/dataType';
 import { ChangeEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useLogsStore, logsStoreReducers } from '../../providers/LogsProvider';
-import {
-	IconGripVertical,
-	IconPin,
-	IconPinFilled,
-	IconLayoutSidebarLeftCollapseFilled,
-	IconLayoutSidebarRightCollapseFilled,
-} from '@tabler/icons-react';
+import { IconChevronsLeft, IconGripVertical, IconPin, IconPinFilled } from '@tabler/icons-react';
 import { DragDropContext, Droppable, Draggable, DropResult } from 'react-beautiful-dnd';
 import { ResizableBox } from 'react-resizable';
 import { useAppStore } from '@/layouts/MainLayout/providers/AppProvider';
-import IconButton from '@/components/Button/IconButton';
 
 const { toggleConfigViewType, toggleDisabledColumns, setOrderedHeaders, togglePinnedColumns, setDisabledColumns } =
 	logsStoreReducers;
+
+const { toggleSideBar } = streamStoreReducers;
 
 const Header = () => {
 	const [configViewType, setLogsStore] = useLogsStore((store) => store.tableOpts.configViewType);
@@ -319,9 +302,10 @@ const ColumnsList = (props: { isLoading: boolean }) => {
 const LogsViewConfig = (props: { schemaLoading: boolean; logsLoading: boolean; infoLoading: boolean }) => {
 	const [configViewType] = useLogsStore((store) => store.tableOpts.configViewType);
 	const [maximized] = useAppStore((store) => store.maximized);
+	const [{ sideBarOpen }, setStreamStore] = useStreamStore((store) => store);
+
 	const divRef = useRef<HTMLDivElement | null>(null);
 	const [height, setHeight] = useState(0);
-	const [isCollapsed, setIsCollapsed] = useState<boolean>(false);
 
 	useEffect(() => {
 		if (divRef.current) {
@@ -329,27 +313,16 @@ const LogsViewConfig = (props: { schemaLoading: boolean; logsLoading: boolean; i
 		}
 	}, [maximized]);
 
-	const toggleCollapse = () => {
-		setIsCollapsed((prev) => !prev);
-	};
-
-	const renderIcon = () => {
-		if (isCollapsed) {
-			return <IconLayoutSidebarLeftCollapseFilled className={classes.columnPinIcon} size="1rem" stroke={1.8} />;
-		} else {
-			return <IconLayoutSidebarRightCollapseFilled className={classes.columnPinIcon} size="1rem" stroke={1.8} />;
-		}
-	};
 	return (
 		<Stack ref={divRef}>
 			<ResizableBox
-				width={isCollapsed ? 0 : LOGS_CONFIG_SIDEBAR_WIDTH}
+				width={sideBarOpen ? 0 : LOGS_CONFIG_SIDEBAR_WIDTH}
 				height={height}
 				axis="x"
 				maxConstraints={[500, height]}
-				minConstraints={[isCollapsed ? 0 : 200, height]}
+				minConstraints={[sideBarOpen ? 0 : 200, height]}
 				style={{
-					transition: 'width 0.3s',
+					transition: 'width 1s',
 				}}>
 				<Stack style={{ width: '100%', height: '100%' }} className={classes.container}>
 					<Header />
@@ -359,10 +332,20 @@ const LogsViewConfig = (props: { schemaLoading: boolean; logsLoading: boolean; i
 						<ColumnsList isLoading={props.logsLoading || props.infoLoading} />
 					)}
 				</Stack>
+				<Stack
+					onClick={() => setStreamStore((store) => toggleSideBar(store))}
+					style={{
+						position: 'absolute',
+						top: '50%',
+						right: '-5%',
+						transform: 'translateY(-50%)',
+						zIndex: 100,
+						backgroundColor: '#fff',
+						borderRadius: '50%',
+					}}>
+					{!sideBarOpen && <IconChevronsLeft />}
+				</Stack>
 			</ResizableBox>
-			<Box style={{ right: 'absolute' }}>
-				<IconButton renderIcon={renderIcon} onClick={toggleCollapse} tooltipLabel="Collapse" />
-			</Box>
 		</Stack>
 	);
 };

--- a/src/pages/Stream/Views/Explore/LogsViewConfig.tsx
+++ b/src/pages/Stream/Views/Explore/LogsViewConfig.tsx
@@ -1,15 +1,34 @@
 import { LOGS_CONFIG_SIDEBAR_WIDTH } from '@/constants/theme';
-import { Checkbox, Divider, Group, ScrollArea, Select, Skeleton, Stack, Text, TextInput, Tooltip } from '@mantine/core';
+import {
+	Box,
+	Checkbox,
+	Divider,
+	Group,
+	ScrollArea,
+	Select,
+	Skeleton,
+	Stack,
+	Text,
+	TextInput,
+	Tooltip,
+} from '@mantine/core';
 import classes from '../../styles/LogsViewConfig.module.css';
 import { useStreamStore } from '../../providers/StreamProvider';
 import _ from 'lodash';
 import { Field } from '@/@types/parseable/dataType';
 import { ChangeEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useLogsStore, logsStoreReducers } from '../../providers/LogsProvider';
-import { IconGripVertical, IconPin, IconPinFilled } from '@tabler/icons-react';
+import {
+	IconGripVertical,
+	IconPin,
+	IconPinFilled,
+	IconLayoutSidebarLeftCollapseFilled,
+	IconLayoutSidebarRightCollapseFilled,
+} from '@tabler/icons-react';
 import { DragDropContext, Droppable, Draggable, DropResult } from 'react-beautiful-dnd';
 import { ResizableBox } from 'react-resizable';
 import { useAppStore } from '@/layouts/MainLayout/providers/AppProvider';
+import IconButton from '@/components/Button/IconButton';
 
 const { toggleConfigViewType, toggleDisabledColumns, setOrderedHeaders, togglePinnedColumns, setDisabledColumns } =
 	logsStoreReducers;
@@ -302,20 +321,36 @@ const LogsViewConfig = (props: { schemaLoading: boolean; logsLoading: boolean; i
 	const [maximized] = useAppStore((store) => store.maximized);
 	const divRef = useRef<HTMLDivElement | null>(null);
 	const [height, setHeight] = useState(0);
+	const [isCollapsed, setIsCollapsed] = useState<boolean>(false);
 
 	useEffect(() => {
 		if (divRef.current) {
 			setHeight(divRef.current.offsetHeight);
 		}
 	}, [maximized]);
+
+	const toggleCollapse = () => {
+		setIsCollapsed((prev) => !prev);
+	};
+
+	const renderIcon = () => {
+		if (isCollapsed) {
+			return <IconLayoutSidebarLeftCollapseFilled className={classes.columnPinIcon} size="1rem" stroke={1.8} />;
+		} else {
+			return <IconLayoutSidebarRightCollapseFilled className={classes.columnPinIcon} size="1rem" stroke={1.8} />;
+		}
+	};
 	return (
 		<Stack ref={divRef}>
 			<ResizableBox
-				width={LOGS_CONFIG_SIDEBAR_WIDTH}
+				width={isCollapsed ? 0 : LOGS_CONFIG_SIDEBAR_WIDTH}
 				height={height}
 				axis="x"
 				maxConstraints={[500, height]}
-				minConstraints={[200, height]}>
+				minConstraints={[isCollapsed ? 0 : 200, height]}
+				style={{
+					transition: 'width 0.3s',
+				}}>
 				<Stack style={{ width: '100%', height: '100%' }} className={classes.container}>
 					<Header />
 					{configViewType === 'schema' ? (
@@ -325,6 +360,9 @@ const LogsViewConfig = (props: { schemaLoading: boolean; logsLoading: boolean; i
 					)}
 				</Stack>
 			</ResizableBox>
+			<Box style={{ right: 'absolute' }}>
+				<IconButton renderIcon={renderIcon} onClick={toggleCollapse} tooltipLabel="Collapse" />
+			</Box>
 		</Stack>
 	);
 };

--- a/src/pages/Stream/Views/Explore/LogsViewConfig.tsx
+++ b/src/pages/Stream/Views/Explore/LogsViewConfig.tsx
@@ -8,7 +8,6 @@ import { ChangeEvent, useCallback, useEffect, useMemo, useRef, useState } from '
 import { useLogsStore, logsStoreReducers } from '../../providers/LogsProvider';
 import { IconChevronsLeft, IconGripVertical, IconPin, IconPinFilled } from '@tabler/icons-react';
 import { DragDropContext, Droppable, Draggable, DropResult } from 'react-beautiful-dnd';
-import { ResizableBox } from 'react-resizable';
 import { useAppStore } from '@/layouts/MainLayout/providers/AppProvider';
 
 const { toggleConfigViewType, toggleDisabledColumns, setOrderedHeaders, togglePinnedColumns, setDisabledColumns } =
@@ -314,38 +313,33 @@ const LogsViewConfig = (props: { schemaLoading: boolean; logsLoading: boolean; i
 	}, [maximized]);
 
 	return (
-		<Stack ref={divRef}>
-			<ResizableBox
-				width={sideBarOpen ? 0 : LOGS_CONFIG_SIDEBAR_WIDTH}
-				height={height}
-				axis="x"
-				maxConstraints={[500, height]}
-				minConstraints={[sideBarOpen ? 0 : 200, height]}
-				style={{
-					transition: 'width 1s',
-				}}>
-				<Stack style={{ width: '100%', height: '100%' }} className={classes.container}>
-					<Header />
-					{configViewType === 'schema' ? (
-						<SchemaList isLoading={props.schemaLoading || props.infoLoading} />
-					) : (
-						<ColumnsList isLoading={props.logsLoading || props.infoLoading} />
-					)}
-				</Stack>
-				<Stack
-					onClick={() => setStreamStore((store) => toggleSideBar(store))}
-					style={{
-						position: 'absolute',
-						top: '50%',
-						right: '-5%',
-						transform: 'translateY(-50%)',
-						zIndex: 100,
-						backgroundColor: '#fff',
-						borderRadius: '50%',
-					}}>
-					{!sideBarOpen && <IconChevronsLeft />}
-				</Stack>
-			</ResizableBox>
+		<Stack
+			ref={divRef}
+			style={{
+				borderRight: '1px solid var(--mantine-color-gray-2)',
+				width: sideBarOpen ? 0 : LOGS_CONFIG_SIDEBAR_WIDTH,
+				transition: 'width 0.5s',
+			}}>
+			<Stack style={{ width: LOGS_CONFIG_SIDEBAR_WIDTH, height: height - 30 }} className={classes.container}>
+				<Header />
+				{configViewType === 'schema' ? (
+					<SchemaList isLoading={props.schemaLoading || props.infoLoading} />
+				) : (
+					<ColumnsList isLoading={props.logsLoading || props.infoLoading} />
+				)}
+			</Stack>
+			<Stack className={classes.collapseBtn}>
+				{!sideBarOpen && (
+					<Tooltip label="Collapse" position="left">
+						<IconChevronsLeft
+							className={classes.collapseIcon}
+							onClick={() => setStreamStore((store) => toggleSideBar(store))}
+							stroke={1.2}
+							size="1.2rem"
+						/>
+					</Tooltip>
+				)}
+			</Stack>
 		</Stack>
 	);
 };

--- a/src/pages/Stream/components/Sidebar.tsx
+++ b/src/pages/Stream/components/Sidebar.tsx
@@ -1,13 +1,6 @@
 import { Stack, Tooltip } from '@mantine/core';
 import classes from '../styles/SideBar.module.css';
-import {
-	IconBolt,
-	IconChevronsRight,
-	IconFilterSearch,
-	IconLayoutSidebarLeftCollapse,
-	IconLayoutSidebarRightCollapse,
-	IconSettings2,
-} from '@tabler/icons-react';
+import { IconBolt, IconChevronsRight, IconFilterSearch, IconSettings2 } from '@tabler/icons-react';
 import { useCallback } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useAppStore } from '@/layouts/MainLayout/providers/AppProvider';
@@ -75,15 +68,13 @@ const ExpandCollapseButton = () => {
 			onClick={() => setStreamStore((store) => toggleSideBar(store))}
 			style={{ padding: '4px 0', alignItems: 'center', marginTop: 'auto' }}
 			className={classes.menuItemContainer}>
-			{/* <Tooltip label={sideBarOpen ? 'Collapse' : 'Expand'} position="right"> */}
-			<Stack style={{ padding: '4px 4px' }}>
-				{sideBarOpen ? (
-					<IconLayoutSidebarRightCollapse stroke={1.2} size="1.2rem" className={classes.icon} color="black" />
-				) : (
-					<IconLayoutSidebarLeftCollapse stroke={1.2} size="1.2rem" className={classes.icon} color="black" />
-				)}
-			</Stack>
-			{/* </Tooltip> */}
+			{sideBarOpen && (
+				<Tooltip label="Expand" position="right">
+					<Stack className={classes.collapseBtn} style={{ padding: '4px 4px' }}>
+						<IconChevronsRight className={classes.collapseIcon} stroke={1.2} size="1.2rem" />
+					</Stack>
+				</Tooltip>
+			)}
 		</Stack>
 	);
 };
@@ -114,7 +105,6 @@ const LiveTailMenu = (props: MenuItemProps) => {
 const SideBar = () => {
 	const [currentStream] = useAppStore((store) => store.currentStream);
 	const [isStandAloneMode] = useAppStore((store) => store.isStandAloneMode);
-	const [{ sideBarOpen }, setStreamStore] = useStreamStore((store) => store);
 	const { view } = useParams();
 	const navigate = useNavigate();
 
@@ -136,27 +126,6 @@ const SideBar = () => {
 			</Stack>
 			<Stack style={{ marginTop: 'auto' }}>
 				<ExpandCollapseButton />
-			</Stack>
-			<Stack
-				onClick={() => setStreamStore((store) => toggleSideBar(store))}
-				style={{
-					position: 'absolute',
-					top: '57%',
-					left: '2.75%',
-					transform: 'translateY(-50%)',
-					zIndex: 100,
-					backgroundColor: '#fff',
-					borderRadius: '50%',
-				}}>
-				<div
-					className={`icon-wrapper ${sideBarOpen ? 'visible' : ''}`}
-					style={{
-						transition: 'opacity 0.3s ease, transform 0.3s ease',
-						opacity: sideBarOpen ? 1 : 0,
-						transform: sideBarOpen ? 'translateX(0)' : 'translateX(-10px)',
-					}}>
-					<IconChevronsRight />
-				</div>
 			</Stack>
 		</Stack>
 	);

--- a/src/pages/Stream/components/Sidebar.tsx
+++ b/src/pages/Stream/components/Sidebar.tsx
@@ -1,11 +1,21 @@
 import { Stack, Tooltip } from '@mantine/core';
 import classes from '../styles/SideBar.module.css';
-import { IconBolt, IconFilterSearch, IconSettings2 } from '@tabler/icons-react';
+import {
+	IconBolt,
+	IconChevronsRight,
+	IconFilterSearch,
+	IconLayoutSidebarLeftCollapse,
+	IconLayoutSidebarRightCollapse,
+	IconSettings2,
+} from '@tabler/icons-react';
 import { useCallback } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useAppStore } from '@/layouts/MainLayout/providers/AppProvider';
 import { STREAM_VIEWS } from '@/constants/routes';
 import _ from 'lodash';
+import { streamStoreReducers, useStreamStore } from '../providers/StreamProvider';
+
+const { toggleSideBar } = streamStoreReducers;
 
 type MenuItemProps = {
 	setCurrentView: (view: string) => void;
@@ -58,6 +68,26 @@ const ConfigButton = (props: MenuItemProps) => {
 	);
 };
 
+const ExpandCollapseButton = () => {
+	const [{ sideBarOpen }, setStreamStore] = useStreamStore((store) => store);
+	return (
+		<Stack
+			onClick={() => setStreamStore((store) => toggleSideBar(store))}
+			style={{ padding: '4px 0', alignItems: 'center', marginTop: 'auto' }}
+			className={classes.menuItemContainer}>
+			{/* <Tooltip label={sideBarOpen ? 'Collapse' : 'Expand'} position="right"> */}
+			<Stack style={{ padding: '4px 4px' }}>
+				{sideBarOpen ? (
+					<IconLayoutSidebarRightCollapse stroke={1.2} size="1.2rem" className={classes.icon} color="black" />
+				) : (
+					<IconLayoutSidebarLeftCollapse stroke={1.2} size="1.2rem" className={classes.icon} color="black" />
+				)}
+			</Stack>
+			{/* </Tooltip> */}
+		</Stack>
+	);
+};
+
 const LiveTailMenu = (props: MenuItemProps) => {
 	const viewName = 'live-tail';
 	const isActive = props.currentView === viewName;
@@ -84,6 +114,7 @@ const LiveTailMenu = (props: MenuItemProps) => {
 const SideBar = () => {
 	const [currentStream] = useAppStore((store) => store.currentStream);
 	const [isStandAloneMode] = useAppStore((store) => store.isStandAloneMode);
+	const [{ sideBarOpen }, setStreamStore] = useStreamStore((store) => store);
 	const { view } = useParams();
 	const navigate = useNavigate();
 
@@ -102,6 +133,30 @@ const SideBar = () => {
 				<AllLogsButton setCurrentView={setCurrentView} currentView={view || ''} />
 				{isStandAloneMode && <LiveTailMenu setCurrentView={setCurrentView} currentView={view || ''} />}
 				<ConfigButton setCurrentView={setCurrentView} currentView={view || ''} />
+			</Stack>
+			<Stack style={{ marginTop: 'auto' }}>
+				<ExpandCollapseButton />
+			</Stack>
+			<Stack
+				onClick={() => setStreamStore((store) => toggleSideBar(store))}
+				style={{
+					position: 'absolute',
+					top: '57%',
+					left: '2.75%',
+					transform: 'translateY(-50%)',
+					zIndex: 100,
+					backgroundColor: '#fff',
+					borderRadius: '50%',
+				}}>
+				<div
+					className={`icon-wrapper ${sideBarOpen ? 'visible' : ''}`}
+					style={{
+						transition: 'opacity 0.3s ease, transform 0.3s ease',
+						opacity: sideBarOpen ? 1 : 0,
+						transform: sideBarOpen ? 'translateX(0)' : 'translateX(-10px)',
+					}}>
+					<IconChevronsRight />
+				</div>
 			</Stack>
 		</Stack>
 	);

--- a/src/pages/Stream/index.tsx
+++ b/src/pages/Stream/index.tsx
@@ -1,5 +1,5 @@
 import { Box, Stack } from '@mantine/core';
-import { useDocumentTitle } from '@mantine/hooks';
+import { useDocumentTitle, useHotkeys } from '@mantine/hooks';
 import { FC, useCallback, useEffect } from 'react';
 import LiveLogTable from './Views/LiveTail/LiveLogTable';
 import ViewLog from './components/ViewLog';
@@ -20,7 +20,7 @@ import { useGetStreamSchema } from '@/hooks/useGetLogStreamSchema';
 import { useGetStreamInfo } from '@/hooks/useGetStreamInfo';
 import useParamsController from './hooks/useParamsController';
 
-const { streamChangeCleanup } = streamStoreReducers;
+const { streamChangeCleanup, toggleSideBar } = streamStoreReducers;
 
 const ErrorView = (props: { error: string | null; onRetry: () => void }) => {
 	return (
@@ -45,11 +45,13 @@ const Stream: FC = () => {
 	const [maximized] = useAppStore((store) => store.maximized);
 	const [instanceConfig] = useAppStore((store) => store.instanceConfig);
 	const queryEngine = instanceConfig?.queryEngine;
-	const [sideBarOpen, setStreamStore] = useStreamStore((store) => store.sideBarOpen);
+	const [, setStreamStore] = useStreamStore((store) => store.sideBarOpen);
 	const { getStreamInfoRefetch, getStreamInfoLoading, getStreamInfoRefetching } = useGetStreamInfo(
 		currentStream || '',
 		currentStream !== null,
 	);
+
+	useHotkeys([['mod+/', () => setStreamStore((store) => toggleSideBar(store))]]);
 
 	const {
 		refetch: refetchSchema,

--- a/src/pages/Stream/index.tsx
+++ b/src/pages/Stream/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Stack, rem } from '@mantine/core';
+import { Box, Stack } from '@mantine/core';
 import { useDocumentTitle } from '@mantine/hooks';
 import { FC, useCallback, useEffect } from 'react';
 import LiveLogTable from './Views/LiveTail/LiveLogTable';
@@ -46,7 +46,7 @@ const Stream: FC = () => {
 	const [instanceConfig] = useAppStore((store) => store.instanceConfig);
 	const queryEngine = instanceConfig?.queryEngine;
 	const getInfoFetchedOnMount = queryEngine === 'Parseable' ? false : currentStream !== null;
-	const [sideBarOpen, setStreamStore] = useStreamStore((store) => store.sideBarOpen);
+	const [, setStreamStore] = useStreamStore((store) => store.sideBarOpen);
 	const { getStreamInfoRefetch, getStreamInfoLoading, getStreamInfoRefetching } = useGetStreamInfo(
 		currentStream || '',
 		getInfoFetchedOnMount,
@@ -78,7 +78,7 @@ const Stream: FC = () => {
 		}
 	}, [isStoreSynced, currentStream]);
 
-	const sideBarWidth = sideBarOpen ? rem(180) : SECONDARY_SIDEBAR_WIDTH;
+	const sideBarWidth = SECONDARY_SIDEBAR_WIDTH;
 
 	if (!currentStream) return null;
 	if (!_.includes(STREAM_VIEWS, view)) return null;

--- a/src/pages/Stream/styles/LogsViewConfig.module.css
+++ b/src/pages/Stream/styles/LogsViewConfig.module.css
@@ -1,5 +1,4 @@
 .container {
-    border: 1px solid var(--mantine-color-gray-2);
     border-top: none;
     border-left: none;
     border-bottom: none;
@@ -109,4 +108,22 @@
 	font-weight: 500;
 	color: var(--mantine-color-brandPrimary-4);
 	cursor: pointer;
+}
+
+.collapseBtn {
+	display: flex;
+	align-items: end;
+	cursor: pointer;
+	padding: 4px;
+}
+
+.collapseIcon{
+	color: var(--mantine-color-gray-6);
+	border-radius: 0.175rem;
+	height: 20px;
+	width: 20px;
+	&:hover {
+		background-color: #F0F3F5;
+		color: black;
+	}
 }

--- a/src/pages/Stream/styles/SideBar.module.css
+++ b/src/pages/Stream/styles/SideBar.module.css
@@ -50,3 +50,18 @@
 .icon {
     color: var(--mantine-color-gray-6);
 }
+
+.collapseBtn {
+	display: flex;
+	align-items: end;
+	cursor: pointer;
+}
+
+.collapseIcon{
+	color: var(--mantine-color-gray-6);
+	border-radius: 0.175rem;
+	&:hover {
+		background-color: #F0F3F5;
+		color: black;
+	}
+}


### PR DESCRIPTION
Collapsed State:

<img width="572" alt="image" src="https://github.com/user-attachments/assets/dbb99bd0-5923-4f12-a098-e906f5c4b567">

Expanded State:

<img width="599" alt="image" src="https://github.com/user-attachments/assets/5c1ce4fd-6700-43fe-97d1-8e491197bc98">


Keyboard Shortcut for Collapsing: `Ctrl + /` or `Cmd + /`