### PR TITLE
Table Cell background color fix

### DIFF
--- a/src/pages/Stream/Views/Explore/StaticLogTable.tsx
+++ b/src/pages/Stream/Views/Explore/StaticLogTable.tsx
@@ -264,15 +264,18 @@ const Table = (props: { primaryHeaderHeight: number }) => {
 						},
 						style: {
 							border: 'none',
-							background: row.index % 2 === 0 ? '#f8f9fa' : 'white',
 							backgroundColor:
-								rowNumber &&
-								(() => {
-									const [start, end] = rowNumber.split(':').map(Number);
-									return row.index >= start && row.index <= end;
-								})()
+								row.index % 2 === 0
+									? rowNumber &&
+									  row.index >= _.toNumber(rowNumber.split(':')[0]) &&
+									  row.index <= _.toNumber(rowNumber.split(':')[1])
+										? '#E8EDFE'
+										: '#f8f9fa'
+									: rowNumber &&
+									  row.index >= _.toNumber(rowNumber.split(':')[0]) &&
+									  row.index <= _.toNumber(rowNumber.split(':')[1])
 									? '#E8EDFE'
-									: '',
+									: 'white',
 						},
 					};
 				}}


### PR DESCRIPTION
**Issue**
The alternating background colour in table view of explore was missing

**Fix**
This PR fixes the issue with the ability of highlight the selected cell without changing the behaviour of the rest of the table