### PR TITLE
Fix: Edit Tile Modal Dashboards

### DIFF
--- a/src/pages/Dashboards/CreateTileForm.tsx
+++ b/src/pages/Dashboards/CreateTileForm.tsx
@@ -37,7 +37,7 @@ const noDataWarning = 'No data available for the query';
 const invalidVizConfig = 'Invalid visualization config';
 
 const { toggleVizEditorModal, toggleCreateTileModal } = dashboardsStoreReducers;
-const { toggleSavedFiltersModal, setAppliedFilterQuery } = filterStoreReducers;
+const { toggleSavedFiltersModal, setAppliedFilterQuery, clearAppliedFilterQuery } = filterStoreReducers;
 const { changeStream } = appStoreReducers;
 
 const getErrorMsg = (form: TileFormType, configType: 'basic' | 'data' | 'viz'): string | null => {
@@ -304,6 +304,7 @@ const Query = (props: { form: TileFormType; onChangeValue: (key: string, value: 
 	useEffect(() => {
 		if (!appliedFilterQuery) return;
 		onEditorChange(appliedFilterQuery);
+		setLogsStore((store) => clearAppliedFilterQuery(store));
 	}, [appliedFilterQuery]);
 
 	const onEditorChange = useCallback((query: string | undefined) => {

--- a/src/pages/Dashboards/CreateTileForm.tsx
+++ b/src/pages/Dashboards/CreateTileForm.tsx
@@ -302,6 +302,7 @@ const Query = (props: { form: TileFormType; onChangeValue: (key: string, value: 
 	const { data: resAIQuery, postLLMQuery } = usePostLLM();
 
 	useEffect(() => {
+		if (!appliedFilterQuery) return;
 		onEditorChange(appliedFilterQuery);
 	}, [appliedFilterQuery]);
 

--- a/src/pages/Stream/providers/FilterProvider.tsx
+++ b/src/pages/Stream/providers/FilterProvider.tsx
@@ -147,6 +147,7 @@ type FilterStoreReducers = {
 	toggleSavedFiltersModal: (_store: FilterStore, val: boolean) => ReducerOutput;
 	applySavedFilters: (store: FilterStore, query: QueryType) => ReducerOutput;
 	setAppliedFilterQuery: (store: FilterStore, query: string | undefined) => ReducerOutput;
+	clearAppliedFilterQuery: (_store: FilterStore) => ReducerOutput;
 };
 
 const { Provider: FilterProvider, useStore: useFilterStore } = initContext(initialState);
@@ -253,6 +254,13 @@ const setAppliedFilterQuery = (_store: FilterStore, query: string | undefined) =
 	return {
 		..._store,
 		appliedFilterQuery: query ?? '',
+	};
+};
+
+const clearAppliedFilterQuery = (_store: FilterStore) => {
+	return {
+		..._store,
+		appliedFilterQuery: '',
 	};
 };
 
@@ -394,6 +402,7 @@ const filterStoreReducers: FilterStoreReducers = {
 	toogleQueryParamsFlag,
 	applySavedFilters,
 	setAppliedFilterQuery,
+	clearAppliedFilterQuery,
 };
 
 export { FilterProvider, useFilterStore, filterStoreReducers };

--- a/src/pages/Stream/providers/FilterProvider.tsx
+++ b/src/pages/Stream/providers/FilterProvider.tsx
@@ -257,6 +257,7 @@ const setAppliedFilterQuery = (_store: FilterStore, query: string | undefined) =
 	};
 };
 
+// clears applied filter query from filter store
 const clearAppliedFilterQuery = (_store: FilterStore) => {
 	return {
 		..._store,


### PR DESCRIPTION
Issue:
navigating to edit tile didn't retain previous tile values

Fix: 
This PR introduces an exit condition to edit option which allows the tile details to retain

Also introduces a new reducer to clear applied filter query