### PR TITLE
remove redundant alerts api call

### DIFF
--- a/src/hooks/useAlertsEditor.tsx
+++ b/src/hooks/useAlertsEditor.tsx
@@ -5,14 +5,14 @@ import { AxiosError, isAxiosError } from 'axios';
 import { useStreamStore, streamStoreReducers } from '@/pages/Stream/providers/StreamProvider';
 const { setAlertsConfig } = streamStoreReducers;
 
-const useAlertsQuery = (streamName: string, hasAlertsAccess: boolean, isStandAloneMode: boolean | null) => {
+const useAlertsQuery = (streamName: string, hasAlertsAccess: boolean, _isStandAloneMode: boolean | null) => {
 	const [, setStreamStore] = useStreamStore(() => null);
 	const { data, isError, isSuccess, isLoading, refetch } = useQuery(
 		['fetch-log-stream-alert', streamName, hasAlertsAccess],
 		() => getLogStreamAlerts(streamName),
 		{
 			retry: false,
-			enabled: streamName !== '' && hasAlertsAccess && !!isStandAloneMode,
+			enabled: false,
 			refetchOnWindowFocus: false,
 			onSuccess: (data) => {
 				setStreamStore((store) => setAlertsConfig(store, data));


### PR DESCRIPTION
This PR removes the redundant alerts api call from the manage page 